### PR TITLE
feat: safari fallback support

### DIFF
--- a/edgeworker/main.js
+++ b/edgeworker/main.js
@@ -13,8 +13,28 @@ const OPTIONS = {
 	},
 };
 
+function isSafari(userAgent) {
+	userAgent = String(userAgent).toLowerCase();
+
+	const hasSafari = userAgent.includes('safari');
+	const hasWebKit = userAgent.includes('applewebkit');
+	const hasVersionTag = userAgent.includes('version/'); // Safari-specific token
+
+	// Exclude other brands (desktop & iOS shells)
+	const otherBrands = /(crios|chrome\/|chromium|edg\/|edgios|fxios|opr\/|opios|samsungbrowser|yabrowser|ucbrowser|brave|vivaldi|electron|duckduckgo)/;
+	const isOther = otherBrands.test(userAgent);
+
+	return hasWebKit && hasSafari && hasVersionTag && !isOther;
+}
+
 export async function onClientRequest(request) {
 	try {
+		const userAgent = request.getHeader('User-Agent');
+
+		if (isSafari(userAgent)) {
+			request.setVariable('PMUSER_EH_BLOCK', '1');
+		}
+
 		const encodedPageUrl = encodeURIComponent(`${request.scheme}://${ORIGIN_SITE_BASE_URL}${request.url}`);
 
 		const url = `https://${HARPER_INSTANCE_APPLICATION_URL}/hints?q=${encodedPageUrl}`;
@@ -30,4 +50,18 @@ export async function onClientRequest(request) {
 	} catch (exception) {
 		logger.log(`Error occured while calling HDB: ${exception.message}`);
 	}
+}
+
+export function onClientResponse(request, response) {
+  if (request.getVariable('PMUSER_EH_BLOCK') !== '1') return;
+
+  if (response.status !== 200) return;
+  const contentType = response.getHeader('Content-Type');
+  if (contentType && !String(contentType).toLowerCase().includes('text/html')) return;
+
+  const hints = request.getVariable('PMUSER_103_HINTS');
+  if (!hints) return;
+
+  // Parse and apply each Early Hint as a Link header for HTML responses for Safari
+  hints.split(/\s*,\s*(?=<)/).forEach(entry => response.addHeader('Link', entry));
 }


### PR DESCRIPTION
Detects if the incoming request is from Safari by analyzing the User-Agent string.

+ onClientRequest --> If Safari is detected, sets a variable to block Early Hints.
+ onClientResponse --> If Safari was detected (block variable set), and the response is HTML and status 200: Parses the hints and adds them as `Link` headers to the response (Safari fallback for preloading).